### PR TITLE
Added Nix support (Flake)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ rustPlatform
+, lib
+, openssl
+, pkg-config
+,
+}:
+let manifest = (lib.importTOML ./Cargo.toml).package;
+in
+rustPlatform.buildRustPackage {
+  pname = manifest.name;
+  version = manifest.version;
+  cargoLock.lockFile = ./Cargo.lock;
+  src = lib.cleanSource ./.;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A CLI tool to watch movies and TV shows";
+    homepage = "https://github.com/eatmynerds/lobster-rs";
+    license = lib.licenses.mit;
+    mainProgram = "lobster-rs";
+    platforms = lib.platforms.windows ++ lib.platforms.unix;
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "A CLI tool to watch movies and TV shows";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      eachSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = eachSystem (system:
+        import nixpkgs {
+          config = { };
+          localSystem = system;
+          overlays = [ ];
+        });
+    in
+    {
+      packages = eachSystem (system: {
+        lobster-rs = pkgsFor.${system}.callPackage ./default.nix { };
+        default = self.packages.${system}.lobster-rs;
+      });
+    };
+}


### PR DESCRIPTION
I added a default.nix, flake.nix and flake.lock files so people can run:
```bash
nix run github:eatmynerds/lobster-rs
```
or add the following to their flake.nix inputs:
```nix
lobster-rs = {
  url = "github:eatmynerds/lobster-rs";
  inputs.nixpkgs.follows = "nixpkgs";
};
```
and then import the `inputs.lobster-rs.packages.${system}.lobster-rs` package.